### PR TITLE
feat: Use `snowflake_account_role` instead of `snowflake_role`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,3 @@ on:
 jobs:
   main:
     uses: getindata/github-workflows/.github/workflows/tf-pre-commit.yml@v1
-    with:
-      # tflint v0.46.0 is the latest version we can use with pre-commit v0.1.20
-      # See .pre-commit-config.yaml for more details.
-      tflint-version: v0.46.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: tflint
         args:
           - --module
-          #- --config=.tflint.hcl
+          - "--config=__GIT_ROOT__/.tflint.hcl"
 
   - repo: https://github.com/terraform-docs/terraform-docs
     rev: "v0.18.0" # Get the latest from: https://github.com/terraform-docs/terraform-docs/releases
@@ -18,7 +18,7 @@ repos:
         args: ["."]
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: "3.2.192" # Get the latest from: https://github.com/bridgecrewio/checkov/releases
+    rev: "3.2.213" # Get the latest from: https://github.com/bridgecrewio/checkov/releases
     hooks:
       - id: checkov
         args: [--skip-check, "CKV_TF_1"] # Terraform module sources do not use a git url with a commit hash revision

--- a/README.md
+++ b/README.md
@@ -154,19 +154,20 @@ For more information, refer to [variables.tf](variables.tf), list of inputs belo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.90 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.94 |
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.90 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.94 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [snowflake_account_role.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/account_role) | resource |
 | [snowflake_grant_account_role.granted_roles](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/grant_account_role) | resource |
 | [snowflake_grant_account_role.granted_to_roles](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/grant_account_role) | resource |
 | [snowflake_grant_account_role.granted_to_users](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/grant_account_role) | resource |
@@ -176,7 +177,6 @@ For more information, refer to [variables.tf](variables.tf), list of inputs belo
 | [snowflake_grant_privileges_to_account_role.account_object_grants](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/grant_privileges_to_account_role) | resource |
 | [snowflake_grant_privileges_to_account_role.schema_grants](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/grant_privileges_to_account_role) | resource |
 | [snowflake_grant_privileges_to_account_role.schema_objects_grants](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/grant_privileges_to_account_role) | resource |
-| [snowflake_role.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/role) | resource |
 <!-- END_TF_DOCS -->
 
 ## CONTRIBUTING

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -67,24 +67,24 @@ terraform destroy -var-file=fixtures.tfvars
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.90 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.94 |
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.90 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.94 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [snowflake_account_role.role_1](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/account_role) | resource |
+| [snowflake_account_role.role_2](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/account_role) | resource |
 | [snowflake_database.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/database) | resource |
 | [snowflake_database_role.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/database_role) | resource |
 | [snowflake_dynamic_table.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/dynamic_table) | resource |
-| [snowflake_role.role_1](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/role) | resource |
-| [snowflake_role.role_2](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/role) | resource |
 | [snowflake_schema.schema_1](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/schema) | resource |
 | [snowflake_schema.schema_2](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/schema) | resource |
 | [snowflake_table.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/table) | resource |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -16,11 +16,11 @@ resource "snowflake_schema" "schema_2" {
   database = snowflake_database.this.name
 }
 
-resource "snowflake_role" "role_1" {
+resource "snowflake_account_role" "role_1" {
   name = "SAMPLE_ROLE_1"
 }
 
-resource "snowflake_role" "role_2" {
+resource "snowflake_account_role" "role_2" {
   name = "SAMPLE_ROLE_2"
 }
 
@@ -65,9 +65,9 @@ module "snowflake_role" {
   role_ownership_grant = "SYSADMIN"
 
   granted_to_users = ["SAMPLE_USER"]
-  granted_to_roles = [snowflake_role.role_1.name]
+  granted_to_roles = [snowflake_account_role.role_1.name]
 
-  granted_roles          = [snowflake_role.role_2.name]
+  granted_roles          = [snowflake_account_role.role_2.name]
   granted_database_roles = ["${snowflake_database.this.name}.${snowflake_database_role.this.name}"]
 
   account_grants = [{
@@ -146,8 +146,8 @@ module "snowflake_role" {
     snowflake_warehouse.this,
     snowflake_schema.schema_1,
     snowflake_schema.schema_2,
-    snowflake_role.role_1,
-    snowflake_role.role_2,
+    snowflake_account_role.role_1,
+    snowflake_account_role.role_2,
     snowflake_database_role.this,
     snowflake_user.this,
     snowflake_table.this,

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.90"
+      version = "~> 0.94"
     }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -68,14 +68,14 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.90 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.94 |
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.90 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.94 |
 
 ## Resources
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.90"
+      version = "~> 0.94"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "role_label" {
   label_value_case    = coalesce(module.this.context.label_value_case, "upper")
 }
 
-resource "snowflake_role" "this" {
+resource "snowflake_account_role" "this" {
   count = module.this.enabled ? 1 : 0
 
   name    = local.name_from_descriptor
@@ -22,28 +22,28 @@ resource "snowflake_grant_ownership" "this" {
   outbound_privileges = "REVOKE"
   on {
     object_type = "ROLE"
-    object_name = one(snowflake_role.this[*].name)
+    object_name = one(snowflake_account_role.this[*].name)
   }
 }
 
 resource "snowflake_grant_account_role" "granted_roles" {
   for_each = toset(module.this.enabled ? var.granted_roles : [])
 
-  parent_role_name = one(snowflake_role.this[*].name)
+  parent_role_name = one(snowflake_account_role.this[*].name)
   role_name        = each.value
 }
 
 resource "snowflake_grant_account_role" "granted_to_roles" {
   for_each = toset(module.this.enabled ? var.granted_to_roles : [])
 
-  role_name        = one(snowflake_role.this[*].name)
+  role_name        = one(snowflake_account_role.this[*].name)
   parent_role_name = each.value
 }
 
 resource "snowflake_grant_account_role" "granted_to_users" {
   for_each = toset(module.this.enabled ? var.granted_to_users : [])
 
-  role_name = one(snowflake_role.this[*].name)
+  role_name = one(snowflake_account_role.this[*].name)
   user_name = each.value
 }
 
@@ -51,14 +51,14 @@ resource "snowflake_grant_database_role" "granted_db_roles" {
   for_each = toset(module.this.enabled ? var.granted_database_roles : [])
 
   database_role_name = each.value
-  parent_role_name   = one(snowflake_role.this[*].name)
+  parent_role_name   = one(snowflake_account_role.this[*].name)
 }
 
 
 resource "snowflake_grant_privileges_to_account_role" "account_grants" {
   for_each = module.this.enabled ? local.account_grants : {}
 
-  account_role_name = one(snowflake_role.this[*].name)
+  account_role_name = one(snowflake_account_role.this[*].name)
   on_account        = true
 
   all_privileges    = each.value.all_privileges
@@ -69,7 +69,7 @@ resource "snowflake_grant_privileges_to_account_role" "account_grants" {
 resource "snowflake_grant_privileges_to_account_role" "account_object_grants" {
   for_each = module.this.enabled ? local.account_objects_grants : {}
 
-  account_role_name = one(snowflake_role.this[*].name)
+  account_role_name = one(snowflake_account_role.this[*].name)
   all_privileges    = each.value.all_privileges
   privileges        = each.value.privileges
   with_grant_option = each.value.with_grant_option
@@ -83,7 +83,7 @@ resource "snowflake_grant_privileges_to_account_role" "account_object_grants" {
 resource "snowflake_grant_privileges_to_account_role" "schema_grants" {
   for_each = module.this.enabled ? local.schema_grants : {}
 
-  account_role_name = one(snowflake_role.this[*].name)
+  account_role_name = one(snowflake_account_role.this[*].name)
   all_privileges    = each.value.all_privileges
   privileges        = each.value.privileges
   with_grant_option = each.value.with_grant_option
@@ -98,7 +98,7 @@ resource "snowflake_grant_privileges_to_account_role" "schema_grants" {
 resource "snowflake_grant_privileges_to_account_role" "schema_objects_grants" {
   for_each = module.this.enabled ? local.schema_objects_grants : {}
 
-  account_role_name = one(snowflake_role.this[*].name)
+  account_role_name = one(snowflake_account_role.this[*].name)
   all_privileges    = each.value.all_privileges
   privileges        = each.value.privileges
   with_grant_option = each.value.with_grant_option

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "name" {
   description = "Name of the role"
-  value       = one(snowflake_role.this[*].name)
+  value       = one(snowflake_account_role.this[*].name)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.90"
+      version = "~> 0.94"
     }
   }
 }


### PR DESCRIPTION
Drop usage of deprecated `snowflake_role` in favor of new `snowflake_account_role` resource.
Other minor improvements